### PR TITLE
'last event' flag for chunked events

### DIFF
--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -595,7 +595,9 @@ class Broker(object):
                                     # last chunk, so last receiver gets the different message
                                     for receiver in receivers_this_chunk[:-1]:
                                         self._router.send(receiver, msg)
-                                    self._router.send(receivers_this_chunk[-1], last_msg)
+                                    # we might have zero valid receivers
+                                    if receivers_this_chunk:
+                                        self._router.send(receivers_this_chunk[-1], last_msg)
 
                                 if receivers:
                                     # still more to do ..

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -49,6 +49,8 @@ from crossbar.router.role import RouterRoleStaticAuth
 from twisted.internet import defer, reactor
 from twisted.test.proto_helpers import Clock
 
+from txaio.testutil import replace_loop
+
 
 class TestBrokerPublish(unittest.TestCase):
     """
@@ -458,49 +460,49 @@ class TestBrokerPublish(unittest.TestCase):
         router.new_correlation_id = lambda: u'fake correlation id'
         router.is_traced = True
         clock = Clock()
-        txaio.config.loop = clock
-        broker = Broker(router, clock)
-        broker._options.event_dispatching_chunk_size = 2
+        with replace_loop(clock):
+            broker = Broker(router, clock)
+            broker._options.event_dispatching_chunk_size = 2
 
-        # let's just "cheat" our way a little to the right state by
-        # injecting our subscription "directly" (e.g. instead of
-        # faking out an entire Subscribe etc. flow
-        # ...so we need _subscriptions_map to have at least one
-        # subscription (our test one) for the topic we'll publish to
-        for session in sessions:
-            broker._subscription_map.add_observer(session, u'test.topic')
+            # let's just "cheat" our way a little to the right state by
+            # injecting our subscription "directly" (e.g. instead of
+            # faking out an entire Subscribe etc. flow
+            # ...so we need _subscriptions_map to have at least one
+            # subscription (our test one) for the topic we'll publish to
+            for session in sessions:
+                broker._subscription_map.add_observer(session, u'test.topic')
 
-        for i, sess in enumerate(sessions):
-            sess._session_id = 1000 + i
-            sess._transport = mock.MagicMock()
-            sess._transport.get_channel_id = mock.MagicMock(return_value=b'deadbeef')
+            for i, sess in enumerate(sessions):
+                sess._session_id = 1000 + i
+                sess._transport = mock.MagicMock()
+                sess._transport.get_channel_id = mock.MagicMock(return_value=b'deadbeef')
 
-        # here's the main "cheat"; we're faking out the
-        # router.authorize because we need it to callback immediately
-        router.authorize = mock.MagicMock(return_value=txaio.create_future_success(dict(allow=True, cache=False, disclose=True)))
+            # here's the main "cheat"; we're faking out the
+            # router.authorize because we need it to callback immediately
+            router.authorize = mock.MagicMock(return_value=txaio.create_future_success(dict(allow=True, cache=False, disclose=True)))
 
-        # now we scan call "processPublish" such that we get to the
-        # condition we're interested in; should go to all sessions
-        # except session0
-        pubmsg = message.Publish(123, u'test.topic')
-        broker.processPublish(session0, pubmsg)
-        clock.advance(1)
-        clock.advance(1)
+            # now we scan call "processPublish" such that we get to the
+            # condition we're interested in; should go to all sessions
+            # except session0
+            pubmsg = message.Publish(123, u'test.topic')
+            broker.processPublish(session0, pubmsg)
+            clock.advance(1)
+            clock.advance(1)
 
-        # extract all the event calls
-        events = [
-            call[1][1]
-            for call in router.send.mock_calls
-            if call[1][0] in [session0, session1, session2, session3, session4]
-        ]
+            # extract all the event calls
+            events = [
+                call[1][1]
+                for call in router.send.mock_calls
+                if call[1][0] in [session0, session1, session2, session3, session4]
+            ]
 
-        # all except session0 should have gotten an event, and
-        # session4's should have the "last" flag set
-        self.assertEqual(4, len(events))
-        self.assertFalse(events[0].correlation_is_last)
-        self.assertFalse(events[1].correlation_is_last)
-        self.assertFalse(events[2].correlation_is_last)
-        self.assertTrue(events[3].correlation_is_last)
+            # all except session0 should have gotten an event, and
+            # session4's should have the "last" flag set
+            self.assertEqual(4, len(events))
+            self.assertFalse(events[0].correlation_is_last)
+            self.assertFalse(events[1].correlation_is_last)
+            self.assertFalse(events[2].correlation_is_last)
+            self.assertTrue(events[3].correlation_is_last)
 
 
 class TestRouterSession(unittest.TestCase):

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -374,6 +374,67 @@ class TestBrokerPublish(unittest.TestCase):
         self.assertEquals(session0._transport.method_calls, [])
         self.assertEquals(session1._transport.method_calls, [])
 
+    def test_publish_traced_events(self):
+        """
+        with two subscribers and message tracing the last event should
+        have a magic flag
+        """
+        # we want to trigger a deeply-nested condition in
+        # processPublish in class Broker -- lets try w/o refactoring
+        # anything first...
+
+        class TestSession(ApplicationSession):
+            pass
+        session0 = TestSession()
+        session1 = TestSession()
+        session2 = TestSession()
+        router = mock.MagicMock()
+        router.send = mock.Mock()
+        router.new_correlation_id = lambda: u'fake correlation id'
+        router.is_traced = True
+        broker = Broker(router, reactor)
+
+        # let's just "cheat" our way a little to the right state by
+        # injecting our subscription "directly" (e.g. instead of
+        # faking out an entire Subscribe etc. flow
+        # ...so we need _subscriptions_map to have at least one
+        # subscription (our test one) for the topic we'll publish to
+        broker._subscription_map.add_observer(session0, u'test.topic')
+        broker._subscription_map.add_observer(session1, u'test.topic')
+
+        session0._session_id = 1000
+        session0._transport = mock.MagicMock()
+        session0._transport.get_channel_id = mock.MagicMock(return_value=b'deadbeef')
+
+        session1._session_id = 1001
+        session1._transport = mock.MagicMock()
+        session1._transport.get_channel_id = mock.MagicMock(return_value=b'deadbeef')
+
+        session2._session_id = 1002
+        session2._transport = mock.MagicMock()
+        session2._transport.get_channel_id = mock.MagicMock(return_value=b'deadbeef')
+
+        # here's the main "cheat"; we're faking out the
+        # router.authorize because we need it to callback immediately
+        router.authorize = mock.MagicMock(return_value=txaio.create_future_success(dict(allow=True, cache=False, disclose=True)))
+
+        # now we scan call "processPublish" such that we get to the
+        # condition we're interested in (this "comes from" session1
+        # beacuse by default publishes don't go to the same session)
+        pubmsg = message.Publish(123, u'test.topic')
+        broker.processPublish(session2, pubmsg)
+
+        # extract all the event calls (the first call is XXX)
+        events = [
+            call[1][1]
+            for call in router.send.mock_calls
+            if call[1][0] in [session0, session1, session2]
+        ]
+
+        self.assertEqual(2, len(events))
+        self.assertFalse(events[0].correlation_is_last)
+        self.assertTrue(events[1].correlation_is_last)
+
 
 class TestRouterSession(unittest.TestCase):
     """

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -47,6 +47,7 @@ from crossbar.router.broker import Broker
 from crossbar.router.role import RouterRoleStaticAuth
 
 from twisted.internet import defer, reactor
+from twisted.test.proto_helpers import Clock
 
 
 class TestBrokerPublish(unittest.TestCase):
@@ -424,7 +425,7 @@ class TestBrokerPublish(unittest.TestCase):
         pubmsg = message.Publish(123, u'test.topic')
         broker.processPublish(session2, pubmsg)
 
-        # extract all the event calls (the first call is XXX)
+        # extract all the event calls
         events = [
             call[1][1]
             for call in router.send.mock_calls
@@ -434,6 +435,72 @@ class TestBrokerPublish(unittest.TestCase):
         self.assertEqual(2, len(events))
         self.assertFalse(events[0].correlation_is_last)
         self.assertTrue(events[1].correlation_is_last)
+
+    def test_publish_traced_events_batched(self):
+        """
+        with two subscribers and message tracing the last event should
+        have a magic flag
+        """
+        # we want to trigger a deeply-nested condition in
+        # processPublish in class Broker -- lets try w/o refactoring
+        # anything first...
+
+        class TestSession(ApplicationSession):
+            pass
+        session0 = TestSession()
+        session1 = TestSession()
+        session2 = TestSession()
+        session3 = TestSession()
+        session4 = TestSession()
+        sessions = [session0, session1, session2, session3, session4]
+        router = mock.MagicMock()
+        router.send = mock.Mock()
+        router.new_correlation_id = lambda: u'fake correlation id'
+        router.is_traced = True
+        clock = Clock()
+        txaio.config.loop = clock
+        broker = Broker(router, clock)
+        broker._options.event_dispatching_chunk_size = 2
+
+        # let's just "cheat" our way a little to the right state by
+        # injecting our subscription "directly" (e.g. instead of
+        # faking out an entire Subscribe etc. flow
+        # ...so we need _subscriptions_map to have at least one
+        # subscription (our test one) for the topic we'll publish to
+        for session in sessions:
+            broker._subscription_map.add_observer(session, u'test.topic')
+
+        for i, sess in enumerate(sessions):
+            sess._session_id = 1000 + i
+            sess._transport = mock.MagicMock()
+            sess._transport.get_channel_id = mock.MagicMock(return_value=b'deadbeef')
+
+        # here's the main "cheat"; we're faking out the
+        # router.authorize because we need it to callback immediately
+        router.authorize = mock.MagicMock(return_value=txaio.create_future_success(dict(allow=True, cache=False, disclose=True)))
+
+        # now we scan call "processPublish" such that we get to the
+        # condition we're interested in; should go to all sessions
+        # except session0
+        pubmsg = message.Publish(123, u'test.topic')
+        broker.processPublish(session0, pubmsg)
+        clock.advance(1)
+        clock.advance(1)
+
+        # extract all the event calls
+        events = [
+            call[1][1]
+            for call in router.send.mock_calls
+            if call[1][0] in [session0, session1, session2, session3, session4]
+        ]
+
+        # all except session0 should have gotten an event, and
+        # session4's should have the "last" flag set
+        self.assertEqual(4, len(events))
+        self.assertFalse(events[0].correlation_is_last)
+        self.assertFalse(events[1].correlation_is_last)
+        self.assertFalse(events[2].correlation_is_last)
+        self.assertTrue(events[3].correlation_is_last)
 
 
 class TestRouterSession(unittest.TestCase):


### PR DESCRIPTION
This makes just one code-path for all dispatching of events and marks the last event that will go out with the flag. Also a couple kind-of-horrific unit-tests

There's still an edge-case here: when in chunked mode, it's possible that the "last chunk" will end up having zero valid receivers by the time we get to it (in which case the previous-to-last chunk should have marks *its* last event as the last one). I can't see any way around this in all cases -- even if we "pre check" the next chunk, all the transports (which might only be 1) *could* become invalid before the next chunk is processed...