### PR TITLE
minor tweaks

### DIFF
--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -248,7 +248,7 @@ class PendingAuthCryptosignProxy(PendingAuthCryptosign):
     def hello(self, realm, details):
         self.log.debug('{klass}.hello(realm={realm}, details={details}) ...',
                        klass=self.__class__.__name__, realm=realm, details=details)
-        if details.authextra:
+        if not details.authextra:
             return types.Deny(message='missing required details.authextra')
         for attr in ['proxy_authid', 'proxy_authrole', 'proxy_realm']:
             if attr not in details.authextra:
@@ -270,4 +270,4 @@ class PendingAuthCryptosignProxy(PendingAuthCryptosign):
 
         self.log.debug('{klass}.hello(realm={realm}, details={details}) -> principal={principal}',
                        klass=self.__class__.__name__, realm=realm, details=details, principal=principal)
-        return principal
+        return self._accept()


### PR DESCRIPTION
okay, so this seems to work decently. I think the same config-options I outlined in the other thread/PR all work here too. Essentially if you want to do dynamic stuff with the *client* credentials, you have to put your dynamic authorizer on the proxy side (instead of "real" backend). That probably makes way more sense anyway.